### PR TITLE
Fixing `database::mysql` recipe dependency

### DIFF
--- a/chef-repo/cookbooks/aar/recipes/default.rb
+++ b/chef-repo/cookbooks/aar/recipes/default.rb
@@ -127,7 +127,7 @@ service "mysql" do
   action [:start, :enable]
 end
 
-include_recipe "database::mysql"
+mysql2_chef_gem 'default'
 
 mysql_connection_info = {
   :host => "localhost",


### PR DESCRIPTION
Replacing `include_recipe 'database::mysql'` that no longer exist.
